### PR TITLE
Add sender constrained tokens (redo)

### DIFF
--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -260,7 +260,7 @@ The following processing rules applies:
 * If the JWT authorization grant in the Access Token Request contains a "requested_cnf" claim:
   * The authorization server in Domain B MUST verify the proof of possession for the private key corresponding to the top level "cnf" claim.
   * The authorization server MUST include the "cnf" value from the "requested_cnf" claim in the returned token.
-* If Domain B does not support sender constrained tokens and the rAccess Token Request is sender constrained, AS-B MAY issue access tokens that are not sender constrained.
+* If Domain B does not support sender constrained tokens and the Access Token Request is sender constrained, AS-B MAY issue access tokens that are not sender constrained.
 * If Domain B requires constrained tokens and the Token Exchange Rquest is not sender constrained, AS-B MUST reject the request and return an error response per Section 5.2 of {{RFC6749}} with invalid_pop as the value of the error parameter.
 
 The following processing rule applies when the authorization server is acting as the Client

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -185,7 +185,7 @@ All of section 2.2 of {{RFC8693}} applies. In addition, the following applies to
 * The "aud" claim included in the returned JWT authorization grant MAY identify multiple authorization servers, provided that trust relationships exist with them (e.g. through federation). It is RECOMMENDED that the "aud" claim is restricted to a single authorization server to prevent an authorization server in one domain from presenting the client's authorization grant to an authorization server in a different trust domain. For example, this will prevent the authorization server in Domain B from presenting the authorization grant it received from the client in Domain A to the authorization server for Domain C.
 
 * If the token exchange request in (B) contains a proof of possession of the Client's private key, the following apply.
-  * AS-A MUST verify the proof of possession in the token exchange request. 
+  * AS-A MUST verify the proof of possession in the token exchange request.
   * AS-A MUST include the “cnf” claim from the “requested_cnf” claim in the token exchange request in the returned authorization grant.
 
 ### Example

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -482,7 +482,7 @@ The editors would like to thank Joe Jubinski, Justin Richer, Aaron Parecki, Dean
 -03
 
 * add sender contrained/proof of possession tokens
-  
+
 -02
 
 * remove recommendation to not use RFC8693's requested_token_type

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -144,7 +144,7 @@ requested_cnf_supported_dpop
 : OPTIONAL. Boolean indicator of whether the authorization server supports DPoP sender constrained tokens.
 When the authorization server is acting as the Client, the Client MAY check whether AS-B supports sender constrained tokens by obtaining the authorization server metadata and verifying "requested_conf_supported" is set to true.
 
-requested_cnf_supported_mtls 
+requested_cnf_supported_mtls
 : OPTIONAL. Boolean indicator of whether the authorization server supports mTLS sender constrained tokens.
 When the authorization server is acting as the Client, the Client MAY check whether AS-B supports sender constrained tokens by obtaining the authorization server metadata and verifying the appropriate sender constrained token method is set to true.
 

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -138,6 +138,14 @@ This specification does not define authorization server discovery. A client MAY 
 ## Sender Constrained Tokens
 Either authorization server MAY issue sender constrained tokens. There are currently two options for sender constrained tokens: Mutually Authenticated TLS (mTLS) {{RFC8705}} and Demonstrating Proof of Possessions (DPoP) {{RFC9449}}.
 
+The following authorization server metadata value is used by this specification when the authorization server is acting as the Client.
+
+{
+   "requested_conf_supported": true
+}
+
+When the authorization server is acting as the Client, the Client MAY check whether AS-B supports sender constrained tokens by obtaining the authorization server metadata and verifying "requested_conf_supported" is set to true.
+
 ## Token Exchange
 
 The client performs token exchange as defined in {{RFC8693}} with the authorization server for its own domain (e.g., Domain A) in order to obtain a JWT authorization grant that can be used with the authorization server of a different domain (e.g., Domain B) as specified in section 1.3 of {{RFC6749}}.
@@ -160,7 +168,7 @@ audience
 
 * If the request itself is not valid or if the given resource or audience are unknown, or are unacceptable based on policy, the authorization server MUST deny the request.
 * The authorization server MAY add, remove or change claims. See [Claims transcription](#claims-transcription).
-* If the inbound token is sender constrained and the resource server is acting as the Client, the Client MUST provide proof of possesssion of a private key, using either mTLS or DPoP, in the token exchange request to AS-A in Step (B). This is not applicable to the authorization server acting as the Client since it performs an "internal token exchange".
+* If the inbound token is sender constrained and the resource server is acting as the Client, the Client MUST provide proof of possession of a private key, using either mTLS or DPoP, in the token exchange request to AS-A in Step (B). This is not applicable to the authorization server acting as the Client since it performs an "internal token exchange".
 
 ### Token Exchange Response
 
@@ -174,7 +182,6 @@ All of section 2.2 of {{RFC8693}} applies. In addition, the following applies to
   * AS-A MUST verify the proof of possession for the token in the request (the initial inbound token)
   * AS-A MUST verify the proof of possession in the token exchange request. 
   * AS-A MUST include the “cnf” claim from the “requested_cnf” claim in the token exchange request in the returned authorization grant.
-
 
 ### Example
 
@@ -229,6 +236,8 @@ scope
 
 The client MAY indicate the audience it is trying to access through the `scope` parameter or the `resource` parameter defined in {{RFC8707}}.
 
+If the authorization server is acting as the Client, the Client MUST include the “cnf” claim from the token exchange request in a “requested_cnf” claim in the returned authorization grant. This does not apply when the resource server is acting as the Client.
+
 ### Processing rules
 
 The authorization server MUST validate the JWT authorization grant as specified in Sections 3 and 3.1 of {{RFC7523}}. The following processing rules also apply:
@@ -244,6 +253,12 @@ The authorization server responds with an access token as described in section 5
 The following process rule applies:
 
 * If the JWT authorization grant in the access token request contains a "requested_cnf" claim, the authorization server MUST include the "cnf" claim from the "requested_cnf" claim in the returned token.
+* If Domain B does not support sender constrained tokens and the request is sender constrained, AS-B MAY issue access tokens that are not sender constrained.
+* If Domain B supports sender constrained tokens and the request is not sender constrained, AS-B MUST reject the request and return an error response per Section 5.2 of {{RFC6749}} with invalid_pop as the value of the error parameter.
+
+The following process rule applies when the authorization server is acting as the Client
+
+* If Domain B supports sender constrained tokens and the JWT authorization grant in the access token request contains a "requested_cnf" claim, the authorization server MUST include the "cnf" claim from the "requested_cnf" claim in the returned token.
 
 ### Example
 


### PR DESCRIPTION
Add sender constrained/proof of possession tokens if the initial inbound token had a proof of possession 