### PR TITLE
Use "Actor" instead of "(abstract) Client"

### DIFF
--- a/diagrams/example-as.puml
+++ b/diagrams/example-as.puml
@@ -5,7 +5,7 @@ skinparam {
 }
 
 participant RSa as "Resource\nServer\nDomain A"
-participant ASa as "Authorization\nServer\nDomain A"
+participant ASa as "Authorization\nServer\nDomain A\n(Actor)"
 participant ASb as "Authorization\nServer\nDomain B"
 participant PRb as "Protected\nResource\nDomain B"
 

--- a/diagrams/example-rs.puml
+++ b/diagrams/example-rs.puml
@@ -5,7 +5,7 @@ skinparam {
 }
 
 participant ASa as "Authorization\nServer\nDomain A"
-participant client as "Resource\nServer\nDomain A"
+participant client as "Resource\nServer\nDomain A\n(Actor)"
 participant ASb as "Authorization\nServer\nDomain B"
 participant pr as "Protected\nResource\nDomain B"
 

--- a/diagrams/identity-chaining-flow.puml
+++ b/diagrams/identity-chaining-flow.puml
@@ -5,7 +5,7 @@ skinparam {
 }
 
 participant ASa as "Authorization\nServer\nDomain A"
-participant client as "Client\nDomain A"
+participant client as "Actor\n(Domain A)"
 participant ASb as "Authorization\nServer\nDomain B"
 participant pr as "Protected\nResource\nDomain B"
 

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -280,7 +280,7 @@ To be added.
 # Security Considerations {#Security}
 
 ## Client Authentication
-Authorization Servers SHOULD follow the OAuth 2.0 Security Best Current Practice {{I-D.ietf-oauth-security-topics}} for client authentication. 
+Authorization Servers SHOULD follow the OAuth 2.0 Security Best Current Practice {{I-D.ietf-oauth-security-topics}} for client authentication.
 
 --- back
 


### PR DESCRIPTION
The term "Client" or "abstract client" is very confusing. Based on the point of view and context the term "client" can mean very different things.

|Point of view|Context|Who is "client"?|
|----|-----|-----|
|AS Domain A|OAuth|Any OAuth client|
|AS Domain A|ID chaining|Either itself, a resource server or any arbitrary OAuth Client|
|RS Domain A|OAuth|Itself or another client that is calling it|
|RS Domain A|ID chaining|Itself or its AS|
|AS Domain B|-|AS or RS in Domain A|
|RS Domain B|OAuth|Itself|
|RS Domain B|ID chaining|AS or RS in Domain A|

If we would continue with the term "client" we would need to always specify exactly from what POV and context. Thus, introducing the role of "actor".